### PR TITLE
Make MDXJSEsm value optional

### DIFF
--- a/complex-types.d.ts
+++ b/complex-types.d.ts
@@ -4,6 +4,7 @@ import {Program} from 'estree-jsx'
 export interface MDXJSEsm extends Literal {
   type: 'mdxjsEsm'
   data?: {estree?: Program} & Literal['data']
+  value?: string
 }
 
 declare module 'mdast' {

--- a/test.js
+++ b/test.js
@@ -215,7 +215,6 @@ test('mdast -> markdown', (t) => {
       {
         type: 'root',
         children: [
-          // @ts-expect-error: `value` missing.
           {type: 'mdxjsEsm'},
           {type: 'paragraph', children: [{type: 'text', value: 'd'}]}
         ]


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

It may be created with without a value.

A practical example can be found [in remark-mdx-frontmatter](https://github.com/remcohaszing/remark-mdx-frontmatter/blob/v1.0.1/src/index.ts#L49-L84).

<!--do not edit: pr-->
