### PR TITLE
Fix types by moving some dev-dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
   ],
   "dependencies": {
     "@types/estree-jsx": "^0.0.1",
-    "@types/mdast": "^3.0.0"
+    "@types/mdast": "^3.0.0",
+    "mdast-util-from-markdown": "^1.0.0",
+    "mdast-util-to-markdown": "^1.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",
     "acorn": "^8.0.0",
     "c8": "^7.0.0",
-    "mdast-util-from-markdown": "^1.0.0",
-    "mdast-util-to-markdown": "^1.0.0",
     "micromark-extension-mdxjs-esm": "^1.0.0",
     "prettier": "^2.0.0",
     "remark-cli": "^9.0.0",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`mdast-util-mdxjs-esm` depends on the types of both `mdast-util-from-markdown` and `mdast-util-to-markdown`.

<!--do not edit: pr-->
