### PR TITLE
Fix TypeScript type imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
  * @typedef {import('mdast-util-to-markdown').Options} ToMarkdownExtension
  * @typedef {import('mdast-util-to-markdown').Handle} ToMarkdownHandle
  * @typedef {import('estree-jsx').Program} Program
- * @typedef {import('./complex-types').MdxjsEsm} MdxjsEsm
+ * @typedef {import('./complex-types.js').MdxjsEsm} MdxjsEsm
  *
  * @typedef {MdxjsEsm} MDXJSEsm - Deprecated name, prefer `MdxjsEsm`
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES2020",
     "lib": ["ES2020"],
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "allowJs": true,
     "checkJs": true,
     "declaration": true,


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TypeScript 4.7 includes the new `node16` module resolution value. This requires imports to have an extension, even if the import doesn’t reference an existing `.js` file.

<!--do not edit: pr-->
